### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ license-files = ["LICEN[CS]E*"]
 [project.urls]
 Homepage = "https://github.com/pypa/sampleproject"
 Issues = "https://github.com/pypa/sampleproject/issues"
+
+[project.optional-dependencies]
+dev = ["pytest"]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from example_package_Leon_Kruse.example import add_one
+
+
+def test_add_one():
+    assert add_one(3) == 4


### PR DESCRIPTION
## Summary
- add pytest test for `add_one`
- specify pytest as a dev optional dependency
- run tests in GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68639218b58c83279c4ee40778d3124c