### PR TITLE
Add TestPyPI publish workflow

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,27 @@
+name: Publish to TestPyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch twine
+      - name: Build package
+        run: hatch build
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: twine upload --repository test dist/*


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the package using Hatch and upload it to TestPyPI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686392e1fc748327941f0754dc827ac2