### PR TITLE
Publish to TestPyPI on release

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,9 +1,8 @@
 name: Publish to TestPyPI
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- update workflow trigger so publishing runs after creating a GitHub release

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686397278ca88327b3adeb48125a71e3