### PR TITLE
Enable VCS versioning in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "example_package_Leon_Kruse"
-version = "0.0.2"
+dynamic = ["version"]
 authors = [
   { name="Example Author", email="author@example.com" },
 ]
@@ -19,8 +19,11 @@ license = "MIT"
 license-files = ["LICEN[CS]E*"]
 
 [project.urls]
-Homepage = "https://github.com/pypa/sampleproject"
-Issues = "https://github.com/pypa/sampleproject/issues"
+Homepage = "https://github.com/Otzel/example-package_Leon_Kruse"
+Issues = "https://github.com/Otzel/example-package_Leon_Kruse/issues"
 
 [project.optional-dependencies]
 dev = ["pytest"]
+
+[tool.hatch.version]
+source = "vcs"


### PR DESCRIPTION
## Summary
- configure the package to derive the version from Git tags
- fix project URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68639ef3781c8327ae273498682d6335