### PR TITLE
Improve docs and package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # Example Package
 
-This is a simple example package.
+This package demonstrates a minimal Python library providing a few helper
+functions to add numbers.
+
+## Installation
+
+```bash
+pip install example-package-Leon-Kruse
+```
+
+## Usage
+
+```python
+from example_package_Leon_Kruse import add_one, add_two, add_three
+
+print(add_one(1))  # 2
+print(add_two(1))  # 3
+print(add_three(1))  # 4
+```
+
+## Versioning
+
+The project uses `hatch-vcs` to derive the package version from Git tags. When
+installed from a release, `__version__` reflects that tag; otherwise it falls
+back to ``0.0.0`` in a local checkout.
+
+## Examples
+
+An executable example is available in `examples/demo.py`.

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,0 +1,5 @@
+from example_package_Leon_Kruse import add_one, add_two, add_three
+
+print("add_one(4) ->", add_one(4))
+print("add_two(4) ->", add_two(4))
+print("add_three(4) ->", add_three(4))

--- a/src/example_package_Leon_Kruse/__init__.py
+++ b/src/example_package_Leon_Kruse/__init__.py
@@ -1,0 +1,13 @@
+"""Example package providing simple arithmetic helpers."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .example import add_one, add_two, add_three
+
+try:  # pragma: no cover - version is provided when installed
+    __version__ = version(__name__)
+except PackageNotFoundError:  # pragma: no cover - fallback for local usage
+    __version__ = "0.0.0"
+
+__all__ = ["add_one", "add_two", "add_three"]
+

--- a/src/example_package_Leon_Kruse/example.py
+++ b/src/example_package_Leon_Kruse/example.py
@@ -1,8 +1,29 @@
 def add_one(number):
+    """Return the given number plus one.
+
+    Example
+    -------
+    >>> add_one(2)
+    3
+    """
     return number + 1
 
 def add_two(number):
+    """Return the given number plus two.
+
+    Example
+    -------
+    >>> add_two(2)
+    4
+    """
     return number + 2
 
 def add_three(number):
+    """Return the given number plus three.
+
+    Example
+    -------
+    >>> add_three(2)
+    5
+    """
     return number + 3

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import example_package_Leon_Kruse as pkg
+
+
+def test_public_api():
+    assert pkg.add_one(1) == 2
+    assert pkg.add_two(1) == 3
+    assert pkg.add_three(1) == 4
+
+
+def test_version():
+    assert hasattr(pkg, '__version__')


### PR DESCRIPTION
## Summary
- document arithmetic helpers and examples
- export helper functions and package version in `__init__`
- expand README with installation, usage, and version info
- add an example script and a small test for the package root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a35cc8a083278829658b309ba872