### PR TITLE
Add BumpyTerrainWrapper example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install --upgrade --index-url https://test.pypi.org/simple/ --no-deps exampl
 ## Usage
 
 ```python
-from example_package_Leon_Kruse import SassyEnvWrapper
+from example_package_Leon_Kruse import SassyEnvWrapper, BumpyTerrainWrapper
 
 class DummyEnv:
     def step(self, action):
@@ -24,6 +24,20 @@ wrapped = SassyEnvWrapper(DummyEnv())
 wrapped.step(0)  # prints a sassy message
 ```
 
+````python
+from dm_control import suite, viewer
+from example_package_Leon_Kruse import BumpyTerrainWrapper
+
+env = suite.load("cartpole", "balance")
+env = BumpyTerrainWrapper(env, bumpiness=2)
+
+# show the environment in a window
+viewer.launch(env)
+
+# you can also grab frames directly
+pixels = env.physics.render(camera_id=0, height=480, width=640)
+````
+
 ## Versioning
 
 The project uses `hatch-vcs` to derive the package version from Git tags. When
@@ -32,4 +46,4 @@ back to ``0.0.0`` in a local checkout.
 
 ## Examples
 
-An executable example is available in `examples/demo.py`.
+Executable examples are available in `examples/demo.py` and `examples/bumpy_demo.py`.

--- a/examples/bumpy_demo.py
+++ b/examples/bumpy_demo.py
@@ -1,0 +1,15 @@
+from dm_control import suite, viewer
+from example_package_Leon_Kruse import BumpyTerrainWrapper
+
+# Load a DeepMind Control Suite environment
+env = suite.load(domain_name="cartpole", task_name="balance")
+
+# Wrap it to adjust terrain bumpiness
+env = BumpyTerrainWrapper(env, bumpiness=2)
+
+# Visualize using the built-in viewer
+viewer.launch(env)
+
+# Retrieve a single frame as an RGB array
+frame = env.physics.render(height=480, width=640, camera_id=0)
+print("Rendered frame shape:", frame.shape)

--- a/src/example_package_Leon_Kruse/__init__.py
+++ b/src/example_package_Leon_Kruse/__init__.py
@@ -2,7 +2,9 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["SassyEnvWrapper"]
+from .bumpy_terrain_wrapper import BumpyTerrainWrapper
+
+__all__ = ["SassyEnvWrapper", "BumpyTerrainWrapper"]
 
 try:  # pragma: no cover - version is provided when installed
     __version__ = version(__name__)

--- a/src/example_package_Leon_Kruse/bumpy_terrain_wrapper.py
+++ b/src/example_package_Leon_Kruse/bumpy_terrain_wrapper.py
@@ -1,0 +1,51 @@
+"""Wrapper to adjust terrain bumpiness in DeepMind Control Suite environments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class BumpyTerrainWrapper:
+    """Adjust height field amplitude to control terrain bumpiness.
+
+    Parameters
+    ----------
+    env:
+        A DeepMind Control Suite environment exposing a ``physics`` attribute.
+    bumpiness:
+        Integer between ``0`` (flat) and ``3`` (extremely bumpy).
+    """
+
+    def __init__(self, env: Any, bumpiness: int = 0) -> None:
+        self.env = env
+        self._original_hfield_data = None
+        self.set_bumpiness(bumpiness)
+
+    def _apply_bumpiness(self) -> None:
+        physics = getattr(self.env, "physics", None)
+        if physics is None:
+            raise AttributeError("Wrapped environment must expose a 'physics' attribute")
+
+        if physics.model.nhfield > 0:
+            if self._original_hfield_data is None:
+                self._original_hfield_data = physics.model.hfield_data.copy()
+            scale = self.bumpiness / 3.0
+            physics.model.hfield_data[:] = self._original_hfield_data * scale
+            physics.forward()
+
+    def set_bumpiness(self, bumpiness: int) -> None:
+        if not 0 <= bumpiness <= 3:
+            raise ValueError("bumpiness must be between 0 and 3")
+        self.bumpiness = bumpiness
+        self._apply_bumpiness()
+
+    def reset(self, *args: Any, **kwargs: Any) -> Any:
+        timestep = self.env.reset(*args, **kwargs)
+        self._apply_bumpiness()
+        return timestep
+
+    def step(self, action: Any) -> Any:
+        return self.env.step(action)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.env, name)

--- a/tests/test_bumpy_terrain_wrapper.py
+++ b/tests/test_bumpy_terrain_wrapper.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from example_package_Leon_Kruse import BumpyTerrainWrapper
+
+
+class Array(list):
+    def copy(self):
+        return Array(self)
+
+    def __mul__(self, other):
+        return Array(x * other for x in self)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+
+class DummyPhysics:
+    def __init__(self, hfield_data):
+        self.model = type('model', (), {
+            'nhfield': 1,
+            'hfield_data': Array(hfield_data)
+        })
+
+    def forward(self):
+        pass
+
+
+class DummyEnv:
+    def __init__(self, hfield_data):
+        self.physics = DummyPhysics(hfield_data)
+
+    def reset(self):
+        return 'reset'
+
+    def step(self, action):
+        return action
+
+
+def test_bumpiness_scales_height_field():
+    env = DummyEnv([1.0, 2.0, 3.0])
+    wrapper = BumpyTerrainWrapper(env, bumpiness=2)
+    expected = Array([x * (2/3.0) for x in [1.0, 2.0, 3.0]])
+    assert env.physics.model.hfield_data == expected
+
+    wrapper.set_bumpiness(0)
+    assert env.physics.model.hfield_data == Array([0.0, 0.0, 0.0])


### PR DESCRIPTION
## Summary
- provide an example for the new `BumpyTerrainWrapper`
- update README usage section with rendering instructions
- add unit test for `BumpyTerrainWrapper`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877529f735083279831d13d6091ffe6